### PR TITLE
Throw error when encounters duplicate key

### DIFF
--- a/ini/INIReader.h
+++ b/ini/INIReader.h
@@ -408,9 +408,11 @@ inline const bool INIReader::BoolConverter(std::string s) const {
 inline int INIReader::ValueHandler(void* user, const char* section,
                                    const char* name, const char* value) {
     INIReader* reader = (INIReader*)user;
-    if (reader->_values[section][name].size() > 0)
-        reader->_values[section][name] += "\n";
-    reader->_values[section][name] += value;
+    if (reader->_values[section][name].size() > 0) {
+        throw std::runtime_error("duplicate key '" + std::string(name) +
+                                 "' in section '" + section + "'.");
+    }
+    reader->_values[section][name] = value;
     return 1;
 }
 }

--- a/ini/INIReader.h
+++ b/ini/INIReader.h
@@ -279,16 +279,13 @@ inline int INIReader::ParseError() const {
             break;
         case -1:
             throw std::runtime_error("ini file not found.");
-            break;
         case -2:
             throw std::runtime_error("memory alloc error");
-            break;
         default:
             throw std::runtime_error("parse error on line no: " +
                                      std::to_string(_error));
-            break;
     }
-    return _error;
+    return 0;
 }
 
 inline const std::set<std::string> INIReader::Sections() const {

--- a/test/fixtures/config.ini
+++ b/test/fixtures/config.ini
@@ -1,7 +1,7 @@
 [section1]
 
 any=1
-any2=true
+any2:true
 not_int = hello
 not_int_arr = a b c d e
 

--- a/test/fixtures/duplicate_keys.ini
+++ b/test/fixtures/duplicate_keys.ini
@@ -1,0 +1,4 @@
+[bad_section]
+foo = hello
+bar = 42
+foo = world

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -108,3 +108,8 @@ TEST(INIReader, read_big_file) {
         EXPECT_EQ(v, i);
     }
 }
+
+TEST(INIReader, dulicate_keys) {
+    EXPECT_THROW(INIReader r{"./fixtures/duplicate_keys.ini"},
+                 std::runtime_error);
+}

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -110,6 +110,6 @@ TEST(INIReader, read_big_file) {
 }
 
 TEST(INIReader, dulicate_keys) {
-    EXPECT_THROW(INIReader r{"./fixtures/duplicate_keys.ini"},
+    EXPECT_THROW(INIReader{"./fixtures/duplicate_keys.ini"},
                  std::runtime_error);
 }


### PR DESCRIPTION
According to Wikipedia, there isn't a standard way to parse duplicate keys in a section. [[link](https://en.wikipedia.org/wiki/INI_file#Duplicate_names)]

Because our parser already accepts an array as value and "[m]ost implementations only support having one property with a given name in a section", I find it most appropriate to throw an error when duplicates are found.